### PR TITLE
add newlines to fix examples haddock

### DIFF
--- a/src/Blockchain/Ethereum/RLP.hs
+++ b/src/Blockchain/Ethereum/RLP.hs
@@ -58,6 +58,7 @@ rlp2Bytes (RLPList os) = do
 -- | Serialize RLPObject to ByteString
 --
 -- Examples:
+--
 -- >>> rlpSerialize $ RLPItem B.empty
 -- "\128"
 -- >>> rlpSerialize $ RLPList []
@@ -91,6 +92,7 @@ bytes2RLP = do
 -- | Deserialize ByteString to RLPObject
 --
 -- Examples:
+--
 -- >>> rlpDeserialize $ B.pack [128]
 -- (Right (RLPItem ""),"")
 -- >>> rlpDeserialize $ B.pack [192]


### PR DESCRIPTION
This makes the doctest examples render as code blocks in the haddock HTML.